### PR TITLE
point to main setup instructions

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -1,7 +1,6 @@
 ---
 layout: page
 title: Setup
-permalink: /setup/
 ---
 
 This lesson is designed to be taught in conjunction with other lessons in the [Data Carpentry Geospatial workshop](http://www.datacarpentry.org/geospatial-workshop/). For information about required software, and to access the datasets used in this lesson, see the [setup instructions](http://www.datacarpentry.org/geospatial-workshop/) on the workshop homepage.

--- a/setup.md
+++ b/setup.md
@@ -1,13 +1,7 @@
 ---
 layout: page
 title: Setup
-root: .
+permalink: /setup/
 ---
 
-This lesson assumes you have the R, RStudio software installed on your computer.
-
-R can be downloaded [here](https://cran.r-project.org/mirrors.html).
-
-RStudio is an environment for developing using R.
-It can be downloaded [here](https://www.rstudio.com/products/rstudio/download/).
-You will need the Desktop version for your computer.
+This lesson is designed to be taught in conjunction with other lessons in the [Data Carpentry Geospatial workshop](http://www.datacarpentry.org/geospatial-workshop/). For information about required software, and to access the datasets used in this lesson, see the [setup instructions](http://www.datacarpentry.org/geospatial-workshop/) on the workshop homepage.


### PR DESCRIPTION
Deprecate individual lesson setup instructions in favor of single, central instructions on workshop homepage.
