### PR TITLE
remove ggplot facet examples and write.table

### DIFF
--- a/_episodes_rmd/07-writing-data.Rmd
+++ b/_episodes_rmd/07-writing-data.Rmd
@@ -64,17 +64,19 @@ Open up this document and have a look.
 > ## Challenge 1
 >
 > Rewrite your 'pdf' command to print a second
-> page in the pdf, showing a facet plot (hint: use `facet_grid`)
-> of the same data with one panel per continent.
+> page in the pdf, showing a line plot of year versus
+> gdp per capita, coloured by country.
 > > ## Solution to challenge 1
 > >
 > > ```{r, eval = FALSE}
 > > pdf("Life_Exp_vs_time.pdf", width = 12, height = 4)
-> > p <- ggplot(data = gapminder, aes(x = year, y = lifeExp, colour = country)) +
+> > ggplot(data = gapminder, aes(x = year, y = lifeExp, colour = country)) +
 > >   geom_line() +
 > >   theme(legend.position = "none")
-> > p
-> > p + facet_grid(. ~continent)
+> > 
+> > ggplot(data = gapminder, aes(x = year, y = gdpPercap, color = country)) +
+> >   geom_line() +
+> >   theme(legend.position = "none")
 > > dev.off()
 > > ```
 > {: .solution}

--- a/_episodes_rmd/07-writing-data.Rmd
+++ b/_episodes_rmd/07-writing-data.Rmd
@@ -90,8 +90,8 @@ documents in different formats.
 
 At some point, you'll also want to write out data from R.
 
-We can use the `write.table` function for this, which is
-very similar to `read.table` from before.
+We can use the `write.csv` function for this, which is
+very similar to `read.csv` from before.
 
 Let's create a data-cleaning script, for this analysis, we
 only want to focus on the gapminder data for Australia:
@@ -99,51 +99,38 @@ only want to focus on the gapminder data for Australia:
 ```{r}
 aust_subset <- gapminder[gapminder$country == "Australia",]
 
-write.table(aust_subset,
-  file="cleaned-data/gapminder-aus.csv",
-  sep=","
+write.csv(aust_subset,
+  file="cleaned-data/gapminder-aus.csv"
 )
 ```
 
-Let's switch back to the shell to take a look at the data to make sure it looks
-OK:
-
-```{r, engine='bash'}
-head cleaned-data/gapminder-aus.csv
-```
-
-Hmm, that's not quite what we wanted. Where did all these
-quotation marks come from? Also the row numbers are
-meaningless.
+Let's open the file to make sure it contains the data we expect. Navigate to your
+`cleaned-data` directory and double-click the file name. It will open using your
+computer's default for opening files with a `.csv` extension. To open in a specific
+application, right click and select the application. Using a spreadsheet program
+(like Excel) to open this file shows us that we do have properly formatted data
+including only the data points from Australia. However, there are row numbers 
+associated with the data that are not useful to us (they refer to the row numbers
+from the gapminder data frame).
 
 Let's look at the help file to work out how to change this
 behaviour.
 
 ```{r, eval=FALSE}
-?write.table
+?write.csv
 ```
 
-By default R will wrap character vectors with quotation marks
-when writing out to file. It will also write out the row and
-column names.
-
-Let's fix this:
+By default R will write out the row and
+column names when writing data to a file.
+To over write this behavior, we can do the following:
 
 ```{r}
-write.table(
-  gapminder[gapminder$country == "Australia",],
+write.csv(
+  aust_subset,
   file="cleaned-data/gapminder-aus.csv",
-  sep=",", quote=FALSE, row.names=FALSE
+  row.names=FALSE
 )
 ```
-
-Now lets look at the data again using our shell skills:
-
-```{r, engine='bash'}
-head cleaned-data/gapminder-aus.csv
-```
-
-That looks better!
 
 > ## Challenge 2
 >
@@ -155,10 +142,10 @@ That looks better!
 > > ## Solution to challenge 2
 > >
 > > ```{r, eval = FALSE}
-> > write.table(
+> > write.csv(
 > >   gapminder[gapminder$year > 1990, ],
 > >   file = "cleaned-data/gapminder-after1990.csv",
-> >   sep = ",", quote = FALSE, row.names = FALSE
+> >   row.names = FALSE
 > > )
 > > ```
 > {: .solution}


### PR DESCRIPTION
Fixes https://github.com/datacarpentry/r-intro-geospatial/issues/9 (remove reference to facet)
Fixes https://github.com/datacarpentry/r-intro-geospatial/issues/22 (replace write.table with write.csv)
Removes reference to opening files in bash shell (not a part of this workshop) and replaces with opening in spreadsheet software to preview.
