### PR TITLE
move content from organization lesson

### DIFF
--- a/_episodes_rmd/02-project-intro.Rmd
+++ b/_episodes_rmd/02-project-intro.Rmd
@@ -22,7 +22,9 @@ knitr_fig_path("02-")
 
 The scientific process is naturally incremental, and many projects
 start life as random notes, some code, then a manuscript, and
-eventually everything is a bit mixed together.
+eventually everything is a bit mixed together. Organising a project involving spatial data is no different from 
+any other data analysis
+project, although you may require more disk space than usual.
 
 <blockquote class="twitter-tweet"><p>Managing your projects in a reproducible fashion doesn't just make your science reproducible, it makes your life easier.</p>— Vince Buffalo (@vsbuffalo) <a href="https://twitter.com/vsbuffalo/status/323638476153167872">April 15, 2013</a></blockquote>
 <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
@@ -105,6 +107,23 @@ analysis. This makes it easier later, as many of my analyses are exploratory
 and don't end up being used in the final project, and some of the analyses
 get shared between projects.
 
+### Keep related data together
+
+Some GIS file formats are really 3-6 files that need to be kept together and have the same name, 
+e.g. shapefiles. It may be tempting to store those components separately, 
+but your spatial data will be unusable if you do that.
+
+### Keep a consistent naming scheme
+It is generally best to avoid renaming downloaded spatial data, 
+so that a clear connection is maintained with the point of truth. 
+You may otherwise find yourself wondering whether `file_A` really is just a copy of `Official_file_on_website` or not.
+
+For datasets you generate, its worth taking the time to come up with a naming convention that works for your project, 
+and sticking to it. File names don't have to be long, they just have to be long enough that you can tell what the file
+is about. Date generated, topic, and whether a product is intermediate or final are good bits of information to keep 
+in a file name. For more tips on naming files, check out [the slides from  
+Jenny Bryan's talk "Naming things" at the 2015 Reproducible Science Workshop](https://speakerdeck.com/jennybc/how-to-name-files).
+
 > ## Tip: Good Enough Practices for Scientific Computing
 >
 > [Good Enough Practices for Scientific Computing](https://github.com/swcarpentry/good-enough-practices-in-scientific-computing/blob/gh-pages/good-enough-practices-for-scientific-computing.pdf) gives the following recommendations for project organization:
@@ -137,3 +156,10 @@ Now we have a good directory structure we will now place/save our data files in 
 > We will load and inspect these data later.
 {: .challenge}
 
+### Stage your scripts
+Creating separate R scripts or Rmarkdown documents for different stages of a project will maximise efficiency. 
+For instance, separating data download commands into their own file means that you won't re-download data unneccesarily.
+
+### Save workspaces
+It may be helpful to set up a folder specifically for saving R workspaces, 
+especially if you have multiple scripts to run in sequence. 

--- a/_episodes_rmd/02-project-intro.Rmd
+++ b/_episodes_rmd/02-project-intro.Rmd
@@ -118,7 +118,7 @@ It is generally best to avoid renaming downloaded spatial data,
 so that a clear connection is maintained with the point of truth. 
 You may otherwise find yourself wondering whether `file_A` really is just a copy of `Official_file_on_website` or not.
 
-For datasets you generate, its worth taking the time to come up with a naming convention that works for your project, 
+For datasets you generate, it's worth taking the time to come up with a naming convention that works for your project, 
 and sticking to it. File names don't have to be long, they just have to be long enough that you can tell what the file
 is about. Date generated, topic, and whether a product is intermediate or final are good bits of information to keep 
 in a file name. For more tips on naming files, check out [the slides from  
@@ -159,7 +159,3 @@ Now we have a good directory structure we will now place/save our data files in 
 ### Stage your scripts
 Creating separate R scripts or Rmarkdown documents for different stages of a project will maximise efficiency. 
 For instance, separating data download commands into their own file means that you won't re-download data unneccesarily.
-
-### Save workspaces
-It may be helpful to set up a folder specifically for saving R workspaces, 
-especially if you have multiple scripts to run in sequence. 


### PR DESCRIPTION
The information from https://datacarpentry.org/organization-geospatial/02-organising-spatial-data/index.html was partially redundant with the information in this episode, but also adds some specific information for working with geospatial data and managing a geospatial project. I've moved that content here and will put in a PR to delete that episode from the organization lesson.