### PR TITLE
add dl link to data structures epsiode

### DIFF
--- a/_episodes_rmd/03-data-structures-part1.Rmd
+++ b/_episodes_rmd/03-data-structures-part1.Rmd
@@ -24,8 +24,9 @@ knitr_fig_path("03-")
 
 One of R's most powerful features is its ability to deal with tabular data -
 such as you may already have in a spreadsheet or a CSV file. Let's start by
-downloading and reading in a file `nordic-data.csv`. We will
-save this data as an object named `nordic`:
+reading in a file `data/nordic-data.csv`. Recall that we downloaded this file
+in the Project Management episode, [follow the download instructions there](https://datacarpentry.org/r-intro-geospatial/02-project-intro#challenge-1)
+if you haven't already done do. We'll load the data as an object named `nordic`:
 
 ```{r}
 nordic <- read.csv("data/nordic-data.csv")

--- a/_episodes_rmd/03-data-structures-part1.Rmd
+++ b/_episodes_rmd/03-data-structures-part1.Rmd
@@ -26,7 +26,7 @@ One of R's most powerful features is its ability to deal with tabular data -
 such as you may already have in a spreadsheet or a CSV file. Let's start by
 reading in a file `data/nordic-data.csv`. Recall that we downloaded this file
 in the Project Management episode, [follow the download instructions there](https://datacarpentry.org/r-intro-geospatial/02-project-intro#challenge-1)
-if you haven't already done do. We'll load the data as an object named `nordic`:
+if you haven't already done so. We'll load the data as an object named `nordic`:
 
 ```{r}
 nordic <- read.csv("data/nordic-data.csv")


### PR DESCRIPTION
As noted in [this issue](https://github.com/datacarpentry/r-intro-geospatial/issues/66), having the download instructions for the data used in this episode buried in a challenge in a previous episode is confusing. As suggested in that issue, I've just linked back to that challenge here; however, I think there's an argument to be made for placing the download instructions right in the lesson so it's self contained and I'd be happy to adjust this PR to do that instead if there's interest.