### PR TITLE
Handle new default stringsAsFactors setting in R v4.0.0

### DIFF
--- a/_episodes_rmd/04-data-structures-part2.Rmd
+++ b/_episodes_rmd/04-data-structures-part2.Rmd
@@ -64,7 +64,7 @@ gapminder <- read.csv("data/gapminder_data.csv")
 >   your computer. For example,
 > 
 > ```{r eval=FALSE, echo=TRUE}
-> gapminder <- read.csv("https://raw.githubusercontent.com/datacarpentry/r-intro-geospatial/master/_episodes_rmd/data/gapminder_data.csv")
+> gapminder <- read.csv("https://raw.githubusercontent.com/datacarpentry/r-intro-geospatial/master/_episodes_rmd/data/gapminder_data.csv", stringsAsFactors = TRUE) #in R version 4.0.0 the default stringsAsFactors changed from TRUE to FALSE. But because below we use some examples to show what is a factor, we need to add the stringAsFactors = TRUE to be able to perform the below examples with factor.
 > ```
 >
 > * You can read directly from excel spreadsheets without


### PR DESCRIPTION
Line 67: when reading the data frame we need to add the stringAsFactors = TRUE because of the recent change from the default option TRUE to FALSE in R version 4.0.0. If we do not do that, all the examples in the lesson regarding factors would not be able to be used.
