### PR TITLE
Adds `kbd` in a missing place and a missing comma

### DIFF
--- a/_episodes_rmd/02-project-intro.Rmd
+++ b/_episodes_rmd/02-project-intro.Rmd
@@ -149,7 +149,7 @@ in a file name. For more tips on naming files, check out [the slides from Jenny 
 Now we have a good directory structure we will now place/save our data files in the `data/` directory.
 
 > ## Challenge 1
-> 1\. Download each of the data files listed below (CTRL + S, right mouse click -> "Save as", or File -> "Save page as")
+> 1\. Download each of the data files listed below (<kbd>Ctrl</kbd>+<kbd>S</kbd>, right mouse click -> "Save as", or File -> "Save page as")
 > 
 > - [nordic country data](https://raw.githubusercontent.com/datacarpentry/r-intro-geospatial/master/_episodes_rmd/data/nordic-data.csv)
 > - [nordic country data (version 2)](https://raw.githubusercontent.com/datacarpentry/r-intro-geospatial/master/_episodes_rmd/data/nordic-data-2.csv)

--- a/_episodes_rmd/08-writing-data.Rmd
+++ b/_episodes_rmd/08-writing-data.Rmd
@@ -80,7 +80,7 @@ Open up this document and have a look.
 {: .challenge}
 
 
-The commands `jpeg`, `png` etc. are used similarly to produce
+The commands `jpeg`, `png`, etc. are used similarly to produce
 documents in different formats.
 
 ## Writing data


### PR DESCRIPTION
Small change to keep the refereces to keyshorts using the <kbd>key</kbd> layout.