### PR TITLE
Add item to dplyr enumerated list

### DIFF
--- a/_episodes_rmd/06-dplyr.Rmd
+++ b/_episodes_rmd/06-dplyr.Rmd
@@ -54,7 +54,8 @@ pipes (`%>%`) to combine them.
 2. `filter()`
 3. `group_by()`
 4. `summarize()`
-5. `mutate()`
+5. `count()` and `n()`
+6. `mutate()`
 
 If you have have not installed this package earlier, please do so:
 


### PR DESCRIPTION
In the introduction to the dplyr package the text states that there are 6 useful functions that will be covered. Only 5 are listed in the enumerated list below the text. Towards the end of this module the count() and the n() functions are described but they were not included in the enumerated list.  I added them to the list so that there are now 6 items that are covered.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
