### PR TITLE
Factor to chr update

### DIFF
--- a/_episodes_rmd/03-data-structures-part1.Rmd
+++ b/_episodes_rmd/03-data-structures-part1.Rmd
@@ -468,15 +468,15 @@ str(nordic[1, ])
 > > ```
 > >
 > > The double brace `[[1]]` returns the contents of the list item. In this case
-> > it is the contents of the first column, a _vector_ of type _factor_.
+> > it is the contents of the first column, a _vector_ of type _character_.
 > >
 > > ```{r, eval=TRUE, echo=TRUE}
 > > nordic$country
 > > ```
 > >
 > > This example uses the `$` character to address items by name. _coat_ is the
-> > first column of the data frame, again a _vector_ of type _factor_.
-> X
+> > first column of the data frame, again a _vector_ of type _character_.
+> >
 > > ```{r, eval=TRUE, echo=TRUE}
 > > nordic["country"]
 > > ```
@@ -489,8 +489,7 @@ str(nordic[1, ])
 > >
 > > This example uses a single brace, but this time we provide row and column
 > coordinates. The returned object is the value in row 1, column 1. The object
-> is an _integer_ but because it is part of a _vector_ of type _factor_, R
-> displays the label "Denmark" associated with the integer value.
+> is a _character_.
 > >
 > > ```{r, eval=TRUE, echo=TRUE}
 > > nordic[, 1]

--- a/_episodes_rmd/03-data-structures-part1.Rmd
+++ b/_episodes_rmd/03-data-structures-part1.Rmd
@@ -235,10 +235,9 @@ your columns of data frames, or you will get nasty surprises!
 > > str(nordic_2$lifeExp)
 > > str(nordic$lifeExp)
 > > ```
-> > The data in `nordic_2$lifeExp` is stored as factors rather than 
+> > The data in `nordic_2$lifeExp` are stored as characters rather than 
 > > numeric. This is because of the "or" character string in the third 
-> > data point. "Factor" is R's special term for categorical data. 
-> > We will be working more with factor data later in this workshop.
+> > data point.
 > {: .solution}
 {: .challenge}
 


### PR DESCRIPTION
To address issues #102 and #105, I changed the references to factor data types to character data types. In Episode 1 of this lesson, the instructions say to download the latest version of R, so I assume all students should be using R 4+ which changes the default option of `stringsAsFactors` to `FALSE`. 

I also removed an `X` that appeared to be a typo, and switched a verb from singular to plural when it referred to data as plural.
