### PR TITLE
Lines 123-128

### DIFF
--- a/_episodes_rmd/01-rstudio-intro.Rmd
+++ b/_episodes_rmd/01-rstudio-intro.Rmd
@@ -121,11 +121,9 @@ file. This console in RStudio is the same as the one you would get if
 you typed in `R` in your command-line environment.
 
 The first thing you will see in the R interactive session is a bunch
-of information, followed by a ">" and a blinking cursor. In many ways
-this is similar to the shell environment you learned about during the
-shell lessons: it operates on the same idea of a "Read, evaluate,
-print loop": you type in commands, R tries to execute them, and then
-returns a result.
+of information, followed by a ">" and a blinking cursor. When you are running
+a section of your code, this is the location where R will first read your code,
+attempt to execute them, and then returns a result.
 
 ## Using R as a calculator
 


### PR DESCRIPTION
Prior to these lines, the learner has not been taught about the shell environment or completed the shell lessons. The comparison between R and the shell environment is lost on the learner, because they don't have any prior experience (at least, within the lesson) or knowledge of shell environments. I think it would make this section less confusing to remove the shell environment language OR include a brief definition of what that means in order to provide some context, IF keeping the 'shell' language in this section is necessary.

(Note: this proposed change is written in partial fulfillment of my Carpentries instructor course checkout process)- Erika Koontz