### PR TITLE
Fix typos

### DIFF
--- a/index.md
+++ b/index.md
@@ -19,7 +19,7 @@ be taught in approximately 4 hours and covers the following topics:
 - Introduction to visualization
 - Writing data to a file
 
-The the [R for Raster and Vector Data](https://datacarpentry.org/r-raster-vector-geospatial/) lesson
+The [R for Raster and Vector Data](https://datacarpentry.org/r-raster-vector-geospatial/) lesson
 provides a more in-depth introduction to visualization (focusing on geospatial data),
 and working with data structures unique to geospatial data.
 
@@ -27,7 +27,7 @@ and working with data structures unique to geospatial data.
 >
 > Data Carpentry's teaching is hands-on, so participants are encouraged to use
 > their own computers to insure the proper setup of tools for an efficient
-> workflow. <br>**This lesson assume no prior knowledge of R.**
+> workflow. <br>**This lesson assumes no prior knowledge of R.**
 >
 > To get started, follow the directions in the "[Setup]({{ relative_root_path }}/{% link setup.md %})" tab to
 > download data to your computer and follow any installation instructions.


### PR DESCRIPTION
Deleted additional 'the' and changed 'assume' to 'assumes'

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
