### PR TITLE
Update 01-rstudio-intro.html

### DIFF
--- a/01-rstudio-intro.html
+++ b/01-rstudio-intro.html
@@ -539,7 +539,7 @@ by R when it executes code.</p>
 <pre class="output" tabindex="0"><code>[1] 5000</code></pre>
 </div>
 <p>Don’t worry about trying to remember every function in R. You can
-look them up on Google, or if you can remember the start of the
+look them up using a web search engine like DuckDuckGo, or if you can remember the start of the
 function’s name, use the tab completion in RStudio.</p>
 <p>This is one advantage that RStudio has over R on its own, it has
 auto-completion abilities that allow you to more easily look up


### PR DESCRIPTION
Removed mention of Google in line 541-543 and replaced it with alternate wording: "using a web search engine like DuckDuckGo"

My reasoning was that if we are to encourage the use of a particular search engine (although I am aware people use the word "Google" to signify searching online in general), it should not be Google.