### PR TITLE
move notes on what to skip to inline

### DIFF
--- a/episodes/03-data-structures-part1.Rmd
+++ b/episodes/03-data-structures-part1.Rmd
@@ -67,6 +67,15 @@ Understanding what happened here is key to successfully analyzing data in R.
 
 ## Data Types
 
+::::::::::::::::::::::::::::::::::::::: instructor
+
+- Learners will work with factors in the following lesson. Be sure to
+  cover this concept.
+- If needed for time reasons, you can skip the section on lists. The learners
+  don't use lists in the rest of the workshop.
+  
+:::::::::::::::::::::::::::::::::::::::
+
 If you guessed that the last command will return an error because `77.2` plus
 `"Denmark"` is nonsense, you're right - and you already have some intuition for an
 important concept in programming called *data classes*. We can ask what class of

--- a/instructors/instructor-notes.md
+++ b/instructors/instructor-notes.md
@@ -43,10 +43,6 @@ geospatial data.
 
 #### [Data Structures](../episodes/03-data-structures-part1.Rmd)
 
-- Learners will work with factors in the following lesson. Be sure to
-  cover this concept.
-- If needed for time reasons, you can skip the section on lists. The learners
-  don't use lists in the rest of the workshop.
 
 #### [Exploring Data Frames](../episodes/04-data-structures-part2.Rmd)
 


### PR DESCRIPTION
The instructor notes page had information about what topics can and can't be skipped in episode 3. This PR moves that information from the instructor notes page to inline, where it will be more easily available to instructors for decision making while they are teaching a workshop. 