### PR TITLE
Fix check issues

### DIFF
--- a/learners/reference.md
+++ b/learners/reference.md
@@ -54,8 +54,6 @@ title: 'Reference'
 ## [Exploring Data Frames](episodes/04-data-structures-part2.Rmd)
 
 - R makes it easy to import datasets storred remotely
-- **[Data Frames](05-data-structures-part2)**
-
 - `?data.frame` is a key data structure. It is a `list` of `vectors`.
 - `cbind()` will add a column (vector) to a data.frame.
 - `rbind()` will add a row (list) to a data.frame.
@@ -217,7 +215,7 @@ not expected by the programming language.
 
 [type]{#type}
 :   The classification of something in a program (for example, the contents of a variable)
-as a kind of number (e.g. [floating-point](#float), [integer](#integer)), [string](#string),
+as a kind of number (e.g. [floating-point](#floating-point-number), [integer](#integer)), [string](#string),
 or something else. In R the command typeof() is used to query a variables type.
 
 [while loop]{#while-loop}


### PR DESCRIPTION
This commit addresses two broken links, flagged by CI in Erin's recent PRs (#133 / #134 ). 

This commit fixes #135 by removing the bullet point "Data Frames". I don't think that bullet point was really adding anything; it _might_ have originally been intended to be formatted differently, like "Useful functions" a few lines below it, but even then I think we're fine to remove it. 

This commit also fixes a missing anchor by updating the "float" link to point at the correct "floating-point-numbers" anchor instead.