### PR TITLE
Update slack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![DOI](https://zenodo.org/badge/128225991.svg)](https://zenodo.org/badge/latestdoi/128225991)
 [![Website](https://github.com/datacarpentry/r-intro-geospatial/actions/workflows/website.yml/badge.svg)](https://github.com/datacarpentry/r-intro-geospatial/actions/workflows/website.yml)
-[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://swc-slack-invite.herokuapp.com/)
-[![Slack Status](https://img.shields.io/badge/Slack_Channel-dc--geospatial-E01563.svg)](https://swcarpentry.slack.com/messages/C9ME7G5RD)
+[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://slack-invite.carpentries.org/)
+[![Slack Status](https://img.shields.io/badge/Slack_Channel-dc--geospatial-E01563.svg)](https://carpentries.slack.com/messages/C9ME7G5RD)
 
 # Intro to R for Geospatial data
 


### PR DESCRIPTION
The Carpentries recently updated their Slack domain URL and invite app URL. This PR updates the links to match the new domains.
