### PR TITLE
Use ggsave instead of pdf - dev.off to save plots

### DIFF
--- a/episodes/08-writing-data.Rmd
+++ b/episodes/08-writing-data.Rmd
@@ -19,8 +19,8 @@ source: Rmd
 
 :::::::::::::::::::::::::::::::::::::::: instructor
 
-Learners will need to have created the directory structure described in 
-[Project Management With RStudio](../episodes/02-project-intro.Rmd) in order 
+Learners will need to have created the directory structure described in
+[Project Management With RStudio](../episodes/02-project-intro.Rmd) in order
 for the code in this episode to work.
 
 ::::::::::::::::::::::::::::::::::::::::
@@ -39,23 +39,18 @@ You can save a plot from within RStudio using the 'Export' button
 in the 'Plot' window. This will give you the option of saving as a
 .pdf or as .png, .jpg or other image formats.
 
-Sometimes you will want to save plots without creating them in the
-'Plot' window first. Perhaps you want to make a pdf document with
-multiple pages: each one a different plot, for example. Or perhaps
-you're looping through multiple subsets of a file, plotting data from
-each subset, and you want to save each plot.
-In this case you can use a more flexible approach. The
-`pdf()` function creates a new pdf device. You can control the size and resolution
-using the arguments to this function.
+Sometimes you will want to save plots without creating them in the 'Plot'
+window first. Perhaps you want to make a pdf document, for example. Or perhaps
+you're looping through multiple subsets of a file, plotting data from each
+subset, and you want to save each plot.
+In this case you can use flexible approach. The `ggsave` function saves the
+latest plot by default. You can control the size and resolution using the
+arguments to this function.
 
 ```{r, eval=FALSE}
-pdf("Distribution-of-gdpPercap.pdf", width=12, height=4)
-ggplot(data = gapminder, aes(x = gdpPercap)) +   
+ggplot(data = gapminder, aes(x = gdpPercap)) +
   geom_histogram()
-
-# You then have to make sure to turn off the pdf device!
-
-dev.off()
+ggsave("Distribution-of-gdpPercap.pdf", width=12, height=4)
 ```
 
 Open up this document and have a look.
@@ -64,33 +59,33 @@ Open up this document and have a look.
 
 ## Challenge 1
 
-Rewrite your 'pdf' command to print a second
-page in the pdf, showing the side-by-side bar
-plot of gdp per capita in countries in the Americas
-in the years 1952 and 2007 that you created in the
+Create and save a new plot showing the side-by-side bar plot of gdp per capita
+in countries in the Americas in the years 1952 and 2007 that you created in the
 previous episode.
+
+
 
 :::::::::::::::  solution
 
 ## Solution to challenge 1
 
 ```{r, eval=FALSE}
-pdf("Distribution-of-gdpPercap.pdf", width = 12, height = 4)
-ggplot(data = gapminder, aes(x = gdpPercap)) + 
-geom_histogram()
-
-ggplot(data = gapminder_small_2, aes(x = country, y = gdpPercap, fill = as.factor(year))) +
-geom_col(position = "dodge") + coord_flip()
-
-dev.off()
+ggplot(data = gapminder_small_2, aes(x = country, y = gdpPercap,
+                                     fill = as.factor(year))) +
+  geom_col(position = "dodge") +
+  coord_flip()
+# Note that ggsave saves by default the latest plot.
+ggsave("Distribution-of-gdpPercap.pdf", width = 12, height = 4)
 ```
 
 :::::::::::::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-The commands `jpeg`, `png`, etc. are used similarly to produce
-documents in different formats.
+To produce documents in different formats, just change the file extension for
+`jpeg`, `png`, `tiff`, or `bmp`.
+
+
 
 ## Writing data
 
@@ -171,7 +166,7 @@ unlink("cleaned-data", recursive=TRUE)
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
-- Save plots using `ggsave()` or `pdf()` combined with `dev.off()`.
+- Save plots using `ggsave()`.
 - Use `write.csv` to save tabular data.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -179,11 +174,11 @@ unlink("cleaned-data", recursive=TRUE)
 
 :::::::::::::::::::::::::::::::::::::::: instructor
 
-- Now that learners know the fundamentals of R, the rest of the workshop will 
+- Now that learners know the fundamentals of R, the rest of the workshop will
   apply these concepts to working with geospatial data in R.
-- Packages and functions specific for working with geospatial data will be the 
+- Packages and functions specific for working with geospatial data will be the
   focus of the rest of the workshop.
-- They will have lots of challenges to practice applying and expanding these 
+- They will have lots of challenges to practice applying and expanding these
   skills in the next lesson.
 
 ::::::::::::::::::::::::::::::::::::::::

--- a/episodes/08-writing-data.Rmd
+++ b/episodes/08-writing-data.Rmd
@@ -82,7 +82,7 @@ ggsave("Distribution-of-gdpPercap.pdf", width = 12, height = 4)
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-To produce documents in different formats, just change the file extension for
+To produce documents in different formats, change the file extension for
 `jpeg`, `png`, `tiff`, or `bmp`.
 
 


### PR DESCRIPTION
Remove the calls to `pdf` and `dev.off` to save plots in lesson 8. We use `ggsave` instead since it fits better with plots built using the `ggplot2`package.

This PR:
- Updates the text in lesson 8.
- Updates challenge 1 in lesson 8.

Closes #121