### PR TITLE
Add new section to lesson 4

### DIFF
--- a/episodes/04-data-structures-part2.Rmd
+++ b/episodes/04-data-structures-part2.Rmd
@@ -87,7 +87,7 @@ str(gapminder)
 ```
 
 We can also examine individual columns of the data frame with the `class` or
-'typeof' functions.:
+'typeof' functions:
 
 ```{r}
 class(gapminder$year)

--- a/episodes/04-data-structures-part2.Rmd
+++ b/episodes/04-data-structures-part2.Rmd
@@ -37,10 +37,10 @@ So far, you have seen the basics of manipulating data frames with our nordic dat
 
 :::::::::::::::::::::::::::::::::::::::::  instructor
 
-Pay attention to and explain the errors and warnings generated from the 
+Pay attention to and explain the errors and warnings generated from the
 examples in this episode.
 
-:::::::::::::::::::::::::::::::::::::::::  
+:::::::::::::::::::::::::::::::::::::::::
 
 ```{r, echo=TRUE}
 gapminder <- read.csv("data/gapminder_data.csv")
@@ -75,7 +75,7 @@ gapminder <- read.csv("https://datacarpentry.org/r-intro-geospatial/data/gapmind
 
 - You can read directly from excel spreadsheets without
   converting them to plain text first by using the [readxl](https://cran.r-project.org/package=readxl) package.
-  
+
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -86,10 +86,12 @@ always do is check out what the data looks like with `str`:
 str(gapminder)
 ```
 
-We can also examine individual columns of the data frame with our `class` function:
+We can also examine individual columns of the data frame with the `class` or
+'typeof' functions.:
 
 ```{r}
 class(gapminder$year)
+typeof(gapminder$year)
 class(gapminder$country)
 str(gapminder$country)
 ```
@@ -280,6 +282,59 @@ tail(gapminder_norway)
 ```
 
 To understand why R is giving us a warning when we try to add this row, let's learn a little more about factors.
+
+
+## Removing columns and rows in data frames
+
+To remove columns from a data frame, we can use the 'subset' function.
+This function allows us to remove columns using their names:
+
+```{r}
+life_expectancy <- subset(gapminder, select = -c(continent, pop, gdpPercap))
+head(life_expectancy)
+```
+
+We can also use a logical vector to achieve the same result. Make sure the
+vector's length match the number of columns in the data frame (to avoid vector
+recycling):
+
+```{r}
+life_expectancy <- gapminder[c(TRUE, TRUE, FALSE, FALSE, TRUE, FALSE)]
+head(life_expectancy)
+```
+
+Alternatively, we can use column's positions:
+
+```{r}
+life_expectancy <- gapminder[-c(3, 4, 6)]
+head(life_expectancy)
+```
+
+Note that the easy way to remove rows from a data frame is selecting the rows
+we want to keep instead.
+Anyway, to remove rows from a data frame, we can use their positions:
+
+```{r}
+# Filter data for Afghanistan during the 20th century:
+afghanistan_20c <- gapminder[gapminder$country == "Afghanistan" &
+                             gapminder$year > 2000, ]
+
+# Now remove data for 2002, that is, the first row:
+afghanistan_20c[-1, ]
+```
+
+
+An interesting case is removing rows containing NAs:
+
+```{r}
+# Turn some values into NAs:
+afghanistan_20c <- gapminder[gapminder$country == "Afghanistan", ]
+afghanistan_20c[afghanistan_20c$year < 2007, "year"] <- NA
+
+# Remove NAs
+na.omit(afghanistan_20c)
+```
+
 
 ## Factors
 

--- a/episodes/04-data-structures-part2.Rmd
+++ b/episodes/04-data-structures-part2.Rmd
@@ -324,7 +324,7 @@ afghanistan_20c[-1, ]
 ```
 
 
-An interesting case is removing rows containing NAs:
+In research, you may want to remove all the missing data prior to an analysis.  Let's first add some missing values (NAs) into the data and then we can use `na.omit()` to remove them.
 
 ```{r}
 # Turn some values into NAs:

--- a/episodes/04-data-structures-part2.Rmd
+++ b/episodes/04-data-structures-part2.Rmd
@@ -337,6 +337,7 @@ For example, you may want to remove all the missing data prior to an analysis.  
 # Turn some values into NAs:
 afghanistan_20c <- gapminder[gapminder$country == "Afghanistan", ]
 afghanistan_20c[afghanistan_20c$year < 2007, "year"] <- NA
+head(afghanistan_20c)
 
 # Remove NAs
 na.omit(afghanistan_20c)

--- a/episodes/04-data-structures-part2.Rmd
+++ b/episodes/04-data-structures-part2.Rmd
@@ -316,7 +316,9 @@ head(life_expectancy)
 ```
 
 Note that typically we select the rows we want to keep, rather than removing rows we do not want in the data.
-However, to remove rows from a data frame, we can use their positions:
+However, to remove rows from a data frame, we can use their positions.
+To practice on a smaller subset, we will filter the data to only those entries from Afghanistan after the year 2000.
+This smaller dataset will be easier for us to inspect by eye and see the changes we are making.
 
 ```{r}
 # Filter data for Afghanistan during the 20th century:

--- a/episodes/04-data-structures-part2.Rmd
+++ b/episodes/04-data-structures-part2.Rmd
@@ -287,7 +287,8 @@ To understand why R is giving us a warning when we try to add this row, let's le
 ## Removing columns and rows in data frames
 
 To remove columns from a data frame, we can use the 'subset' function.
-This function allows us to remove columns using their names:
+This function allows us to remove columns using their names.
+If we want to keep all columns except continent, pop and gdpPercap we can use the following `subset` command:
 
 ```{r}
 life_expectancy <- subset(gapminder, select = -c(continent, pop, gdpPercap))

--- a/episodes/04-data-structures-part2.Rmd
+++ b/episodes/04-data-structures-part2.Rmd
@@ -330,7 +330,8 @@ afghanistan_20c[-1, ]
 ```
 
 
-In research, you may want to remove all the missing data prior to an analysis.  Let's first add some missing values (NAs) into the data and then we can use `na.omit()` to remove them.
+In research, we often remove rows based on features of the data itself, rather than its location.
+For example, you may want to remove all the missing data prior to an analysis.  Let's first add some missing values (NAs) into the data and then we can use `na.omit()` to remove them.
 
 ```{r}
 # Turn some values into NAs:

--- a/episodes/04-data-structures-part2.Rmd
+++ b/episodes/04-data-structures-part2.Rmd
@@ -303,10 +303,15 @@ life_expectancy <- gapminder[c(TRUE, TRUE, FALSE, FALSE, TRUE, FALSE)]
 head(life_expectancy)
 ```
 
+:::::: spoiler
+
+### Vector Recycling
+
 Vector recycling occurs when working with vectors of different length and it
 consist on repeating the elements of the shorter vector up to the lenght of
 the larger one. For more information, check the book R for Data Science and its
 [chapter about vectors](https://r4ds.had.co.nz/vectors.html#scalars-and-recycling-rules).
+::::::::
 
 Alternatively, we can use column positions:
 

--- a/episodes/04-data-structures-part2.Rmd
+++ b/episodes/04-data-structures-part2.Rmd
@@ -316,7 +316,7 @@ life_expectancy <- gapminder[-c(3, 4, 6)]
 head(life_expectancy)
 ```
 
-Note that the easy way to remove rows from a data frame is selecting the rows
+Note that typically we select the rows we want to keep, rather than removing rows we do not want in the data.
 we want to keep instead.
 However, to remove rows from a data frame, we can use their positions:
 

--- a/episodes/04-data-structures-part2.Rmd
+++ b/episodes/04-data-structures-part2.Rmd
@@ -296,7 +296,9 @@ head(life_expectancy)
 ```
 
 We can also use a logical vector to achieve the same result. Make sure the
-vector's length match the number of columns in the data frame (to avoid R repeating the shorter vector to match the length of the longer vector, called "vector recycling"):
+vector's length matches the number of columns in the data frame (to avoid R
+repeating the shorter vector to match the length of the longer vector, called
+"vector recycling"):
 
 ```{r}
 life_expectancy <- gapminder[c(TRUE, TRUE, FALSE, FALSE, TRUE, FALSE)]
@@ -308,7 +310,7 @@ head(life_expectancy)
 ### Vector Recycling
 
 Vector recycling occurs when working with vectors of different length and it
-consist on repeating the elements of the shorter vector up to the lenght of
+consist of repeating the elements of the shorter vector up to the length of
 the larger one. For more information, check the book R for Data Science and its
 [chapter about vectors](https://r4ds.had.co.nz/vectors.html#scalars-and-recycling-rules).
 ::::::::

--- a/episodes/04-data-structures-part2.Rmd
+++ b/episodes/04-data-structures-part2.Rmd
@@ -303,7 +303,7 @@ life_expectancy <- gapminder[c(TRUE, TRUE, FALSE, FALSE, TRUE, FALSE)]
 head(life_expectancy)
 ```
 
-Alternatively, we can use column's positions:
+Alternatively, we can use column positions:
 
 ```{r}
 life_expectancy <- gapminder[-c(3, 4, 6)]

--- a/episodes/04-data-structures-part2.Rmd
+++ b/episodes/04-data-structures-part2.Rmd
@@ -312,7 +312,7 @@ head(life_expectancy)
 
 Note that the easy way to remove rows from a data frame is selecting the rows
 we want to keep instead.
-Anyway, to remove rows from a data frame, we can use their positions:
+However, to remove rows from a data frame, we can use their positions:
 
 ```{r}
 # Filter data for Afghanistan during the 20th century:

--- a/episodes/04-data-structures-part2.Rmd
+++ b/episodes/04-data-structures-part2.Rmd
@@ -316,7 +316,6 @@ head(life_expectancy)
 ```
 
 Note that typically we select the rows we want to keep, rather than removing rows we do not want in the data.
-we want to keep instead.
 However, to remove rows from a data frame, we can use their positions:
 
 ```{r}

--- a/episodes/04-data-structures-part2.Rmd
+++ b/episodes/04-data-structures-part2.Rmd
@@ -304,6 +304,11 @@ life_expectancy <- gapminder[c(TRUE, TRUE, FALSE, FALSE, TRUE, FALSE)]
 head(life_expectancy)
 ```
 
+Vector recycling occurs when working with vectors of different length and it
+consist on repeating the elements of the shorter vector up to the lenght of
+the larger one. For more information, check the book R for Data Science and its
+[chapter about vectors](https://r4ds.had.co.nz/vectors.html#scalars-and-recycling-rules).
+
 Alternatively, we can use column positions:
 
 ```{r}

--- a/episodes/04-data-structures-part2.Rmd
+++ b/episodes/04-data-structures-part2.Rmd
@@ -296,7 +296,7 @@ head(life_expectancy)
 ```
 
 We can also use a logical vector to achieve the same result. Make sure the
-vector's length match the number of columns in the data frame (to avoid R repeating the shorter vector to match the length of the longer vector):
+vector's length match the number of columns in the data frame (to avoid R repeating the shorter vector to match the length of the longer vector, called "vector recycling"):
 
 ```{r}
 life_expectancy <- gapminder[c(TRUE, TRUE, FALSE, FALSE, TRUE, FALSE)]

--- a/episodes/04-data-structures-part2.Rmd
+++ b/episodes/04-data-structures-part2.Rmd
@@ -296,8 +296,7 @@ head(life_expectancy)
 ```
 
 We can also use a logical vector to achieve the same result. Make sure the
-vector's length match the number of columns in the data frame (to avoid vector
-recycling):
+vector's length match the number of columns in the data frame (to avoid R repeating the shorter vector to match the length of the longer vector):
 
 ```{r}
 life_expectancy <- gapminder[c(TRUE, TRUE, FALSE, FALSE, TRUE, FALSE)]


### PR DESCRIPTION
Closes #118 

This PR:
- adds a new section about removing columns and rows from data frames.
- adds an example and a reference to the functions `typeof` and `na.omit`.

These changes addresses the issues raised by @sstevens2, regarding objectives missed by lesson 4.
